### PR TITLE
fix(build.yml/configure): update to using Ubuntu 22.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,9 +8,6 @@
 # @author Connor Henley, @thatging3rkid
 name: "Build PDF"
 
-runs:
-  using: 'node16'  # use latest LTS version of NodeJS for GitHub actions (like checkout)
-
 on:
   # run on a push to every branch but master
   push:
@@ -27,14 +24,14 @@ jobs:
 
     steps:
       # checkout the repository (pull master on release)
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         if: github.event_name == 'release'
         with:
           fetch-depth: 0
           ref: ${{ github.event.release.target_commitish }}
           
       # checkout the repository
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         if: github.event_name == 'push'
         with:
           fetch-depth: 0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest # use latest since this won't be run often (backup: 18.04)
+    runs-on: ubuntu-22.04  # this has been tested to work with Ubuntu 22.04, some day it will need to be updated!
 
     steps:
       # checkout the repository (pull master on release)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,9 @@
 # @author Connor Henley, @thatging3rkid
 name: "Build PDF"
 
+runs:
+  using: 'node16'  # use latest LTS version of NodeJS for GitHub actions (like checkout)
+
 on:
   # run on a push to every branch but master
   push:

--- a/configure
+++ b/configure
@@ -23,7 +23,8 @@ if ! [ -x "$(command -v pdflatex)" ]; then
     # Setup MiKTeX and enable auto-package installation
     sudo miktexsetup --shared=yes finish && sudo initexmf --admin --set-config-value [MPM]AutoInstall=1
     sudo mpm --admin --set-repository=http://mirrors.rit.edu/CTAN/systems/win32/miktex/tm/packages/
-    sudo mpm --admin --update-db # update database, should fix auto-package installation
+    sudo mpm --admin --update-db  # update database, should fix auto-package installation
+    sudo mpm --admin --update  # update everything before first runtime
 fi
 
 # Install GhostScript (used for compression)

--- a/configure
+++ b/configure
@@ -24,9 +24,8 @@ if ! [ -x "$(command -v pdflatex)" ]; then
     sudo miktexsetup --shared=yes finish
     sudo initexmf --admin --set-config-value [MPM]AutoInstall=1
 
-    # Use RIT mirrors and update the database from said mirrors
-    #sudo mpm --admin --set-repository=http://mirrors.rit.edu/CTAN/systems/win32/miktex/tm/packages/  # currently, MPM doesn't like using RIT's mirror
-    sudo mpm --admin --update-db  # update database, should fix auto-package installation
+    # update the database, this should allow auto-install to work
+    sudo mpm --admin --update-db
 
     # according to this comment, MiKTeX needs to be updated multiple times smh
     # https://github.com/MiKTeX/miktex/issues/724#issuecomment-785949728

--- a/configure
+++ b/configure
@@ -21,10 +21,19 @@ if ! [ -x "$(command -v pdflatex)" ]; then
     fi
 
     # Setup MiKTeX and enable auto-package installation
-    sudo miktexsetup --shared=yes finish && sudo initexmf --admin --set-config-value [MPM]AutoInstall=1
-    sudo mpm --admin --set-repository=http://mirrors.rit.edu/CTAN/systems/win32/miktex/tm/packages/
+    sudo miktexsetup --shared=yes finish
+    sudo initexmf --admin --set-config-value [MPM]AutoInstall=1
+
+    # Use RIT mirrors and update the database from said mirrors
+    #sudo mpm --admin --set-repository=http://mirrors.rit.edu/CTAN/systems/win32/miktex/tm/packages/  # currently, MPM doesn't like using RIT's mirror
     sudo mpm --admin --update-db  # update database, should fix auto-package installation
-    sudo mpm --admin --update  # update everything before first runtime
+
+    # according to this comment, MiKTeX needs to be updated multiple times smh
+    # https://github.com/MiKTeX/miktex/issues/724#issuecomment-785949728
+    sudo mpm --admin --update
+    mpm --update
+    sudo mpm --admin --update
+    mpm --update
 fi
 
 # Install GhostScript (used for compression)


### PR DESCRIPTION
# Changes

This PR updates the automated build system to use an Ubuntu 22.04 (latest LTS release) runner, which should be supported for a few more years (5+ hopefully). I dug through the MiKTeX documentation and it looks like it's setup instructions haven't changed, though I fixed a few deprecation warnings.